### PR TITLE
chore(ios): update LeanSDK xcframework source link to latest distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class LeanTestAppApp: App {
         Lean.manager.setup(
             appToken: "YOUR_APP_TOKEN",
             sandbox: true,
-            version: "1.25.0"
+            version: "build.32"
         )
     }
 
@@ -98,7 +98,7 @@ struct ContentView: View {
 
 ### Setting the version
 
-`version` takes a `String` and can point to either a specific SDK version i.e. `"1.25.0"` or an alias i.e. `"latest"`.
+`version` takes a `String` and can point to either a specific SDK version i.e. `"build.32"` or an alias i.e. `"latest"`.
 
 We recommend passing in a specific version to ensure stability in the case that a change to the SDK breaks your application.
 
@@ -161,7 +161,7 @@ class ViewController: UIViewController {
         Lean.manager.setup(
             appToken: "YOUR_APP_TOKEN",
             sandbox: true,
-            version: "1.25.0",
+            version: "build.32",
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note: You must have github connected to XCode for SPM to work.
 
 ### Manually
 
-You can download the `LeanSDK.xcframework` file manually [here](https://cdn.leantech.me/link/sdk/ios/1.5.0/LeanSDK.xcframework-1.5.0.zip).
+You can download the `LeanSDK.xcframework` file manually [here](https://cdn.leantech.me/link/sdk/ios/build.32/LeanSDK.xcframework-build.32.zip).
 
 You can then add it to your project the same way you would with any other framework dependency.
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,18 @@ You can then add it to your project the same way you would with any other framew
 
 <br/>
 
-### Ionic / Capacitor
+### Ionic / Capacitor (unofficial)
 
-If you are using [Ionic](https://ionicframework.com/) with [Capacitor](https://capacitorjs.com/), the community plugin [lean-ionic-capacitor](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor) wraps this iOS SDK (plus the Android and Web SDKs) behind one JavaScript API.
+This plugin is **not an official Lean product**. It is an independent community wrapper built on top of Lean's official iOS, Android, and Web SDKs.
+
+If you are using [Ionic](https://ionicframework.com/) with [Capacitor](https://capacitorjs.com/), see [lean-ionic-capacitor](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor).
 
 ```
 npm install lean-ionic-capacitor
 npx cap sync
 ```
 
-See the [plugin repository](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor) for host-app setup, deep linking, and usage examples.
+See the [plugin repository](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor) for host-app setup, deep linking, and usage examples. Lean does not maintain or support this plugin.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note: You must have github connected to XCode for SPM to work.
 
 ### Manually
 
-You can download the `LeanSDK.xcframework` file manually [here](https://cdn.leantech.me/link/sdk/ios/build.32/LeanSDK.xcframework-build.32.zip).
+You can download the `LeanSDK.xcframework` file manually [here](https://cdn.leantech.me/link/sdk/ios/build.39/LeanSDK.xcframework-build.39.zip).
 
 You can then add it to your project the same way you would with any other framework dependency.
 
@@ -41,7 +41,7 @@ class LeanTestAppApp: App {
         Lean.manager.setup(
             appToken: "YOUR_APP_TOKEN",
             sandbox: true,
-            version: "build.32"
+            version: "1.25.0"
         )
     }
 
@@ -98,7 +98,7 @@ struct ContentView: View {
 
 ### Setting the version
 
-`version` takes a `String` and can point to either a specific SDK version i.e. `"build.32"` or an alias i.e. `"latest"`.
+`version` takes a `String` and can point to either a specific Link SDK version i.e. `"1.25.0"` or an alias i.e. `"latest"`. This is the web SDK loaded at runtime; it is separate from the native xcframework build in the [manual download](#manually) link and `Package.swift`.
 
 We recommend passing in a specific version to ensure stability in the case that a change to the SDK breaks your application.
 
@@ -161,7 +161,7 @@ class ViewController: UIViewController {
         Lean.manager.setup(
             appToken: "YOUR_APP_TOKEN",
             sandbox: true,
-            version: "build.32",
+            version: "1.25.0",
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ You can then add it to your project the same way you would with any other framew
 
 <br/>
 
+### Ionic / Capacitor
+
+If you are using [Ionic](https://ionicframework.com/) with [Capacitor](https://capacitorjs.com/), the community plugin [lean-ionic-capacitor](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor) wraps this iOS SDK (plus the Android and Web SDKs) behind one JavaScript API.
+
+```
+npm install lean-ionic-capacitor
+npx cap sync
+```
+
+See the [plugin repository](https://github.com/imuhammadnadeem/LEAN-Ionic-Capacitor) for host-app setup, deep linking, and usage examples.
+
+<br/>
+
 ## Usage with Swift UI
 
 Once the package has been added to your project, you should initialize the SDK within your app.


### PR DESCRIPTION
chore(ios): update LeanSDK xcframework source link to latest distribution

- Switch Lean iOS distribution artifact to build.32 URL:
  https://cdn.leantech.me/link/sdk/ios/build.32/LeanSDK.xcframework-build.32.zip
